### PR TITLE
Add test case for inserting 1M rows by trans

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "extends": "standard"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tmp
+sqlite
 better
 package-lock.json
 

--- a/betterPerformance.js
+++ b/betterPerformance.js
@@ -2,8 +2,10 @@
 
 const betterSqlite = require('./betterSqlite')
 
-async function testBetterSqlitePerformance (nums) {
+async function testBetterSqlitePerformance (nums, transParams) {
   // const nums = new Array(999).fill().map((v, i) => i) // 999
+  // const transParams = new Array(1000000).fill()
+  //   .map((v, number) => ({ number }))
   await betterSqlite.startBetterSqlLite()
   await betterSqlite.setPragma()
   await betterSqlite.resetBetterSqlTable()
@@ -22,11 +24,16 @@ async function testBetterSqlitePerformance (nums) {
   console.log('findTakes: ', findTakes)
   // Inserting the hole array at once is similar to performing just one insert.
   // Parallel seems slower than synchronous
+
+  const instArrByTransTakes = await testInsertArrayByTrans(transParams)
+  console.log('instArrByTransTakes: ', instArrByTransTakes)
+
   return {
     oneByOneTakes,
     parallelTakes,
     instArrTakes,
-    findTakes
+    findTakes,
+    instArrByTransTakes
   }
 }
 
@@ -55,6 +62,13 @@ async function testInsertArray (nums) {
   if (nums.length > 999) throw new Error('Arr cant be bigger than 999')
   const start = Date.now()
   await betterSqlite.insertManyNums(nums)
+  const end = Date.now()
+  return end - start
+}
+
+async function testInsertArrayByTrans (params) {
+  const start = Date.now()
+  await betterSqlite.insertManyNumsByTrans(params)
   const end = Date.now()
   return end - start
 }

--- a/betterPerformance.js
+++ b/betterPerformance.js
@@ -52,7 +52,7 @@ async function testInsertParallel (nums) {
 }
 
 async function testInsertArray (nums) {
-  if (nums.length > 9999) throw new Error('Arr cant be bigger than 999')
+  if (nums.length > 999) throw new Error('Arr cant be bigger than 999')
   const start = Date.now()
   await betterSqlite.insertManyNums(nums)
   const end = Date.now()

--- a/betterSqlite.js
+++ b/betterSqlite.js
@@ -9,6 +9,12 @@ const rimraf = require('rimraf')
 const tmpDir = path.join(__dirname, 'better')
 const dbPathAbsolute = tmpDir
 const caller = { ctx: { root: __dirname } }
+const workerPathAbsolute = path.join(
+  __dirname,
+  'node_modules',
+  'bfx-facs-db-better-sqlite',
+  'test/extended-worker/index.js'
+)
 
 rimraf.sync(tmpDir)
 mkdirp.sync(tmpDir)
@@ -17,7 +23,7 @@ mkdirp.sync(tmpDir)
 // database.run( 'PRAGMA journal_mode = WAL;' )
 const betterFac = new BetterSqliteFac(
   caller,
-  { dbPathAbsolute, timeout: 20000 }
+  { dbPathAbsolute, workerPathAbsolute, timeout: 20000 }
 )
 
 async function startBetterSqlLite () {
@@ -69,6 +75,14 @@ async function insertManyNums (params) {
   })
 }
 
+async function insertManyNumsByTrans (params) {
+  return betterFac.asyncQuery({
+    action: 'RUN_IN_TRANS',
+    sql: 'INSERT INTO numbers(number) VALUES($number)',
+    params
+  })
+}
+
 async function findVals (params = []) {
   let sql = 'SELECT number FROM numbers'
   if (params.length) sql += ' WHERE number = ?'
@@ -85,5 +99,6 @@ module.exports = {
   insertNum,
   insertManyNums,
   findVals,
-  resetBetterSqlTable
+  resetBetterSqlTable,
+  insertManyNumsByTrans
 }

--- a/index.js
+++ b/index.js
@@ -7,14 +7,16 @@ const sqlN = 'SqlLite3'
 
 async function compare () {
   const nums = new Array(999).fill().map((v, i) => i)
+  const transParams = new Array(1000000).fill()
+    .map((v, number) => ({ number }))
   console.log('-----------------------------------')
   console.log(`Test ${betN} Performance: `)
   console.log('')
-  const betterSqlite = await testBetterSqlitePerformance(nums)
+  const betterSqlite = await testBetterSqlitePerformance(nums, transParams)
   console.log('-----------------------------------')
   console.log(`Test ${sqlN} Performance: `)
   console.log('')
-  const sqlite = await testSqlitePerformance(nums)
+  const sqlite = await testSqlitePerformance(nums, transParams)
   console.log('-----------------------------------')
   console.log(`Comparison between ${betN} and ${sqlN} Performance: `)
   console.log('')
@@ -37,6 +39,11 @@ async function compare () {
     'Find All',
     betterSqlite.findTakes,
     sqlite.findTakes
+  )
+  checkPerformance(
+    'Array insertions by transaction',
+    betterSqlite.instArrByTransTakes,
+    sqlite.instArrByTransTakes
   )
   console.log('-----------------------------------')
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ async function compare () {
     sqlite.findTakes
   )
   console.log('-----------------------------------')
+
+  process.exit(0)
 }
 
 function checkPerformance (fnc, bet, sql) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "bfx-facs-db-better-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-better-sqlite.git",
     "bfx-facs-db-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-sqlite.git",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "sqlite3": "^5.0.0"
   },
   "engine": {
     "node": ">=12.16.0"

--- a/sqlite.js
+++ b/sqlite.js
@@ -14,7 +14,7 @@ mkdirp.sync(tmpDir)
 SqliteFac.ctx = { root: '' }
 // database.run( 'PRAGMA journal_mode = WAL;' )
 const sqliteFac = new SqliteFac(SqliteFac, {
-  db: path.join(__dirname, 'tmp', 'test.db'),
+  db: path.join(__dirname, 'sqlite', 'test.db'),
   dirConf: path.join(__dirname, 'sqliteconf'),
   runSqlAtStart: [
     'CREATE TABLE IF NOT EXISTS numbers (number INT);',

--- a/sqlite.js
+++ b/sqlite.js
@@ -23,6 +23,38 @@ const sqliteFac = new SqliteFac(SqliteFac, {
   ]
 })
 
+function _run (sql, params = []) {
+  return new Promise((resolve, reject) => {
+    sqliteFac.db.run(sql, params, function (err) {
+      if (err) {
+        reject(err)
+
+        return
+      }
+
+      resolve(this)
+    })
+  })
+}
+
+function _parallelize (fn) {
+  return new Promise((resolve, reject) => {
+    try {
+      sqliteFac.db.parallelize(async function () {
+        try {
+          const res = await fn()
+
+          resolve(res)
+        } catch (err) {
+          reject(err)
+        }
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
 async function startSqlLite () {
   return new Promise((resolve, reject) => {
     sqliteFac._start((err, res) => {
@@ -77,6 +109,45 @@ async function insertManyNums (params) {
   })
 }
 
+async function insertManyNumsByTrans (params) {
+  return new Promise((resolve, reject) => {
+    sqliteFac.db.serialize(async () => {
+      let isTransBegun = false
+
+      try {
+        await _run('BEGIN TRANSACTION')
+        isTransBegun = true
+
+        const res = await _parallelize(async () => {
+          const promises = []
+
+          for (const { number } of params) {
+            const promise = insertNum(number)
+            promises.push(promise)
+          }
+
+          await Promise.all(promises)
+        })
+
+        await _run('COMMIT')
+        resolve(res)
+      } catch (err) {
+        try {
+          if (isTransBegun) {
+            await _run('ROLLBACK')
+          }
+        } catch (err) {
+          reject(err)
+
+          return
+        }
+
+        reject(err)
+      }
+    })
+  })
+}
+
 async function findVals (params = []) {
   return new Promise((resolve, reject) => {
     let sql = 'SELECT number FROM numbers'
@@ -93,5 +164,6 @@ module.exports = {
   insertNum,
   insertManyNums,
   findVals,
-  resetSqlLiteTable
+  resetSqlLiteTable,
+  insertManyNumsByTrans
 }

--- a/sqlitePerformance.js
+++ b/sqlitePerformance.js
@@ -2,8 +2,10 @@
 
 const sqlite = require('./sqlite')
 
-async function testSqlitePerformance (nums) {
+async function testSqlitePerformance (nums, transParams) {
   // const nums = new Array(999).fill().map((v, i) => i) // 999
+  // const transParams = new Array(1000000).fill()
+  //   .map((v, number) => ({ number }))
   await sqlite.startSqlLite()
   const oneByOneTakes = await testInsertOneByOne(nums)
   console.log('oneByOneTakes: ', oneByOneTakes)
@@ -20,11 +22,15 @@ async function testSqlitePerformance (nums) {
   console.log('findTakes: ', findTakes)
   // Inserting the hole array at once is similar to performing just one insert.
   // Parallel is faster than synchronous
+
+  const instArrByTransTakes = await testInsertArrayByTrans(transParams)
+  console.log('instArrByTransTakes: ', instArrByTransTakes)
   return {
     oneByOneTakes,
     parallelTakes,
     instArrTakes,
-    findTakes
+    findTakes,
+    instArrByTransTakes
   }
 }
 
@@ -53,6 +59,13 @@ async function testInsertArray (nums) {
   if (nums.length > 999) throw new Error('Arr cant be bigger than 999')
   const start = Date.now()
   await sqlite.insertManyNums(nums)
+  const end = Date.now()
+  return end - start
+}
+
+async function testInsertArrayByTrans (params) {
+  const start = Date.now()
+  await sqlite.insertManyNumsByTrans(params)
   const end = Date.now()
   return end - start
 }


### PR DESCRIPTION
This PR adds a test case for inserting 1M rows by transaction. Basic changes:
  - Bumps sqlite3 up to 5.0.0
  - Fixes sqlite db dir path
  - Adds test case for inserting 1M rows by trans

Results of comparison between `better-sqlite3` and `sqlite3` performance:

```
-----------------------------------
Test Better-SqlLite3 Performance: 

oneByOneTakes:  90
parallelTakes:  1006
instArrTakes:  3
findTakes:  49
instArrByTransTakes:  2378
-----------------------------------
Test SqlLite3 Performance: 

oneByOneTakes:  75
parallelTakes:  20
instArrTakes:  1
findTakes:  53
instArrByTransTakes:  14037
-----------------------------------
Comparison between Better-SqlLite3 and SqlLite3 Performance: 

In Simple insertions, SqlLite3 is 1.20X times faster
In Parallel insertions, SqlLite3 is 50.30X times faster
In Array insertions, SqlLite3 is 3.00X times faster
In Find All, Better-SqlLite3 is 1.08X times faster
In Array insertions by transaction, Better-SqlLite3 is 5.90X times faster
-----------------------------------
```